### PR TITLE
Composite primary/foreign key fix

### DIFF
--- a/lib/avo/fields/belongs_to_field.rb
+++ b/lib/avo/fields/belongs_to_field.rb
@@ -194,7 +194,7 @@ module Avo
           return [:"#{polymorphic_as}_type", :"#{polymorphic_as}_id"]
         end
 
-        foreign_key.to_sym
+        foreign_key.is_a?(Array) ? foreign_key.map(&:to_sym) : foreign_key.to_sym                                                                                                                                                       
       end
 
       def fill_field(record, key, value, params)


### PR DESCRIPTION
Fixes https://github.com/avo-hq/avo/issues/3334

Fix `NoMethodError: undefined method `to_sym' for an instance of Array` raised by this line when an association uses a composite primary key/foreign key.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the [documentation](https://github.com/avo-hq/avodocs)
- [ ] I have added tests that prove my fix is effective or that my feature works
